### PR TITLE
Allow any rake version (including 10.x) while still avoiding the gem warning

### DIFF
--- a/leveldb-native.gemspec
+++ b/leveldb-native.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_development_dependency("minitest", ["~> 5.0"])
-  s.add_development_dependency("rake", "~> 0.9")
+  s.add_development_dependency("rake", "~> 0")
 end


### PR DESCRIPTION
Unfortunately the gem warning makes it hard to get (1) both a clean build and (2) really allow any version of rake to be used (especially when both rake 0.9 and 10.0 are fine). The solution is to use `~> 0` to allow any version, but not warn.
