### PR TITLE
Allow configuration of lib and include path through 'leveldb' name

### DIFF
--- a/ext/leveldb_native/extconf.rb
+++ b/ext/leveldb_native/extconf.rb
@@ -1,5 +1,7 @@
 require 'mkmf'
 
+dir_config('leveldb')
+
 have_library "leveldb" or abort "Can't find leveldb library."
 
 create_makefile "leveldb-native/leveldb_native"


### PR DESCRIPTION
Hi,

On Windows pretty painful to generate a Makefile which contains the correct path of leveldb headers without this option, bacause no 'ususal' path like on Linux. 
This change allow to pass extra path to mkmf, e.g.:

```
gem install leveldb-native -- --with-leveldb-dir=/g/tmp/leveldb-mingw-master
gem install leveldb-native -- --with-leveldb-lib=/g/tmp/leveldb-mingw-master/lib
gem install leveldb-native -- --with-leveldb-include=/g/tmp/leveldb-mingw-master/include
```

The same works with `rake compile`.
